### PR TITLE
Update Voatz

### DIFF
--- a/program-list/program-list.json
+++ b/program-list/program-list.json
@@ -8661,12 +8661,12 @@
   },
   {
     "program_name": "Voatz",
-    "policy_url": "https://hackerone.com/voatz",
+    "policy_url": "https://new.voatz.com/disclosure-policy/",
     "submission_url": "",
     "launch_date": "",
-    "bug_bounty": true,
+    "bug_bounty": false,
     "swag": false,
-    "hall_of_fame": true,
+    "hall_of_fame": false,
     "safe_harbor": "none"
   },
   {


### PR DESCRIPTION
# Summary
HackerOne removed Voatz from its platform on 03/20 (https://www.cyberscoop.com/voatz-hackerone-bug-bounty-election-security/). Updated to include their new policy.

One question is whether we should list this as having a bug bounty program. Voatz does maintain a "bug bounty" at https://voatzinc.atlassian.net/servicedesk/customer/portals, but given a lack of terms / definitions of payment and scope, I don't think this qualifies as a bug bounty.

# Quality Assurance Checklist
< confirmation of this pull request meeting the following requirements, prior to merge >
| Review Items                            | Y/N |
|-----------------------------------------|-----|
| Site has a publicly known bug bounty    |    ? (see above) |
| Disclosure terms are publicly available |    Yes (disclosure solely subject to Voatz's determination) |
| Public URL                              |   Y  |
| Single Source, or all sources appended  |    Y |
