### PR TITLE
Add Whatbox

### DIFF
--- a/program-list/program-list.json
+++ b/program-list/program-list.json
@@ -8850,6 +8850,16 @@
     "safe_harbor": "partial"
   },
   {
+    "program_name": "Whatbox",
+    "policy_url": "https://whatbox.ca/policies/security",
+    "submission_url": "security@whatbox.ca",
+    "launch_date": "2013-12-03",
+    "bug_bounty": true,
+    "swag": false,
+    "hall_of_fame": true,
+    "safe_harbor": "full"
+  },
+  {
     "program_name": "Whmcs",
     "policy_url": "https://bugcrowd.com/whmcs",
     "submission_url": "https://bugcrowd.com/whmcs/report",


### PR DESCRIPTION
# Summary
Add Whatbox to the bug bounty list.

# Quality Assurance Checklist
| Review Items                            | Y/N |
|-----------------------------------------|-----|
| Site has a publicly known bug bounty    |  Y   |
| Disclosure terms are publicly available |  Y  |
| Public URL                              |  Y  |
| Single Source, or all sources appended  |  Y  |

# Commentary
Just discovered disclose.io! We've been strong advocates for bug bounty programs for years.

I appreciate the effort you have put into better protecting researchers. While full safe harbour was always implied in our program, we never had the terminology to guarantee it for researchers. You had country-specific terms ready to go for us!